### PR TITLE
Changed split function, which reads new search log

### DIFF
--- a/searchstats.py
+++ b/searchstats.py
@@ -115,8 +115,12 @@ def main():
   for line in search_log:    # Iterate through lines of the log file.
     if first_line:    # If this is the first line, we need to figure out what
                       # kind of file we've received (search log or partnerlog).
-      if (len(((line.split())[0]).split('.')) == 7)or(len(((line.split())[0]).split('.')) == 4):
-        # True for both formats 10.10.10.10!10.10.10.10 -- [21/Oct/2015:08:45:57 -0800] and 10.10.10.10 -- [21/Oct/2015:08:45:57 -0800] 
+      if (len(((line.split())[0]).split('.')) == 7)or(
+	len(((line.split())[0]).split('.')) == 4):
+        # True for both formats 
+	#"10.10.10.10!10.10.10.10 -- [21/Oct/2015:08:45:57 -0800]"
+	# and 
+	#"10.10.10.10 -- [21/Oct/2015:08:45:57 -0800]"
         # The log file entries start with an IP address, so we assume that it's
         # a search log.  Set our correct field and split variables.
         split_on = " "

--- a/searchstats.py
+++ b/searchstats.py
@@ -115,7 +115,8 @@ def main():
   for line in search_log:    # Iterate through lines of the log file.
     if first_line:    # If this is the first line, we need to figure out what
                       # kind of file we've received (search log or partnerlog).
-      if len(((line.split())[0]).split('.')) == 7:
+      if (len(((line.split())[0]).split('.')) == 7)or(len(((line.split())[0]).split('.')) == 4):
+        # True for both formats 10.10.10.10!10.10.10.10 -- [21/Oct/2015:08:45:57 -0800] and 10.10.10.10 -- [21/Oct/2015:08:45:57 -0800] 
         # The log file entries start with an IP address, so we assume that it's
         # a search log.  Set our correct field and split variables.
         split_on = " "

--- a/searchstats.py
+++ b/searchstats.py
@@ -115,7 +115,7 @@ def main():
   for line in search_log:    # Iterate through lines of the log file.
     if first_line:    # If this is the first line, we need to figure out what
                       # kind of file we've received (search log or partnerlog).
-      if (len(((line.split())[0]).split('.')) == 7)or(
+      if (len(((line.split())[0]).split('.')) == 7) or (
 	len(((line.split())[0]).split('.')) == 4):
         # True for both formats 
 	#"10.10.10.10!10.10.10.10 -- [21/Oct/2015:08:45:57 -0800]"

--- a/searchstats.py
+++ b/searchstats.py
@@ -115,7 +115,7 @@ def main():
   for line in search_log:    # Iterate through lines of the log file.
     if first_line:    # If this is the first line, we need to figure out what
                       # kind of file we've received (search log or partnerlog).
-      if len(((line.split())[0]).split('.')) == 4:
+      if len(((line.split())[0]).split('.')) == 7:
         # The log file entries start with an IP address, so we assume that it's
         # a search log.  Set our correct field and split variables.
         split_on = " "


### PR DESCRIPTION
Format we have  10.20.30.20!10.20.30.20 was not parsed with error "web_log.log is not a search log or partnerlog".
It is fixed now.
