### PR TITLE
Fixing bug when support script output is not saved.

### DIFF
--- a/gsa_admin.py
+++ b/gsa_admin.py
@@ -862,7 +862,8 @@ class gsaWebInterface:
 
     # support script submitted, check whether output is available
     
-    param = urllib.urlencode({"actionType": "supportScripts"})
+    param = urllib.urlencode({"actionType": "supportScripts",
+                              "a": "1"})
     request = urllib2.Request(self.baseURL + "?" + param)
     tm = 0
     sleeptime = 4
@@ -883,7 +884,7 @@ class gsaWebInterface:
     param = urllib.urlencode({"actionType": "supportScripts",
                               "security_token": security_token,
                               "download": "Download results from previous run",
-                              "action": "download"})
+                              "doaction": "download"})
     request = urllib2.Request(self.baseURL, param)
     result = self._openurl(request)
     content = result.read()


### PR DESCRIPTION
Due to changes in support script form, few actions changed to properly track support script execution and properly grab output in file.
Tested: 7.4, 7.6, 7.6.50